### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ShrikantAzDev/1c3d077b-29a3-4337-9817-b9cf0f31426e/cfe46e69-0b1d-492c-bc73-3a8348a5bb0a/_apis/work/boardbadge/4311f44f-b63b-479b-a48e-d46ef022bcc9)](https://dev.azure.com/ShrikantAzDev/1c3d077b-29a3-4337-9817-b9cf0f31426e/_boards/board/t/cfe46e69-0b1d-492c-bc73-3a8348a5bb0a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/ShrikantAzDev/1c3d077b-29a3-4337-9817-b9cf0f31426e/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.